### PR TITLE
Fix problem with dropping source names in weights

### DIFF
--- a/R/calc_projections.R
+++ b/R/calc_projections.R
@@ -122,8 +122,7 @@ weights_from_src <- function(src_pts, weights = NULL){
     weights <- default_weights[unique(src_pts$data_src)]
   }
 
-  weights %>% as.tibble() %>%
-    `names<-`("weight") %>% rownames_to_column('data_src')
+  weights %>% tibble(data_src = names(.), weight = .)
 }
 
 #' Calculate Standard Deviations for Projected Points

--- a/R/calc_projections.R
+++ b/R/calc_projections.R
@@ -186,8 +186,7 @@ aggregate_stats <- function(data_result, src_weights = NULL){
     src_weights <- default_weights[data_src]
   }
 
-  weight_tbl <- src_weights %>% as.tibble() %>%
-    `names<-`("weight") %>% rownames_to_column('data_src')
+  weight_tbl <- src_weights %>% tibble(data_src = names(.), weight = .)
 
   data_result %>% stats_by_category() %>%
     map(inner_join, weight_tbl, by = "data_src") %>%


### PR DESCRIPTION
The old code caused the names (sources) in the weights vector to be dropped.  This caused multiple problems later in projections_table().