### PR TITLE
updating schedule_data allowing package to install

### DIFF
--- a/R/schedule_data.R
+++ b/R/schedule_data.R
@@ -1,6 +1,6 @@
-schedule_url <- "https://www70.myfantasyleague.com/2019/export?TYPE=nflSchedule&W=ALL&JSON=1"
+schedule_url <- "https://api.myfantasyleague.com/2019/export?TYPE=nflSchedule&W=ALL&JSON=1"
 
-schedule_data <- schedule_url %>% GET() %>% content() %>%
+schedule_data <- schedule_url %>% httr::GET() %>% httr::content() %>%
   .[[c("fullNflSchedule", "nflSchedule")]] %>% purrr:::keep(~ "matchup" %in% names(.))
 
 names(schedule_data) <- paste0("week_", 1:length(schedule_data))
@@ -8,20 +8,24 @@ names(schedule_data) <- paste0("week_", 1:length(schedule_data))
 schedule_data <- schedule_data %>%
   purrr::map(~ `names<-`(.x$matchup, paste0("match_", seq_along(.x$matchup))))
 
-
-first_last_games <- schedule_data %>% purrr::modify_depth(2, `[[`, "kickoff") %>%
+# The nesting structure does not work well with the superbowl, manually added below as "last" game
+first_last_games <- schedule_data[-21] %>% purrr::modify_depth(2, `[[`, "kickoff") %>%
   purrr::map(unlist, use.name = FALSE) %>% purrr::map(as.numeric) %>% purrr::map(summary) %>%
   purrr::map(`[`, c("Min.", "Max.")) %>%
   purrr::map(~ as.POSIXct(as.numeric(.x), origin = "1970-01-01")) %>%
   purrr::map(`names<-`, c("first", "last"))
 
-
+first_last_games$week21 <- setNames(rep(as.POSIXct(as.numeric(schedule_data$week_21$match_1), origin = "1970-01-01"), 2), 
+                                    c("first", "last"))
 
 scrape_start_date <- first_last_games %>% purrr::map_chr(`[[`, "last") %>% lag %>% as.numeric() %>%
   as.POSIXct(origin = "1970-01-01") %>% as.Date()
 
 scrape_start_date[1] <-  first_last_games %>% purrr::map_chr(`[[`, "first") %>% min %>% as.numeric() %>%
-  as.POSIXct(origin = "1970-01-01") %>% as.Date() %>% `-`(7)
+  as.POSIXct(origin = "1970-01-01") %>% as.Date() %>% `-`(7) # I would use below code, this adds a day because 
+# 20:20 EDT bumps it to the next day UTC when switching to as.Date()
+
+scrape_start_date[1] <- as.Date(format(first_last_games$week_1[["first"]], format = "%Y-%m-%d")) - 7L
 
 scrape_start_date[18:21] <- scrape_start_date[17] + c(7,14,21,35)
 


### PR DESCRIPTION
Right now installation fails when prepping data for lazyloading because the API pull from myfantasyleague.com was not working correctly. This fixes that and an issue related to pulling the kickoff time from the superbowl (the kickoff time is both the first and the last game now). This fix should be good for the offseason / until the 2020 schedule function is ready to go. Tested this & the other pull request by downloading the package and installing it locally and it worked great.