### PR TITLE
Fixed Walterfootball not pulling MFL IDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ffanalytics
 Type: Package
 Title: Scrape Data For Fantasy Football
-Version: 3.1.2.0002
+Version: 3.1.2.0003
 Authors@R: c(person("Dennis", "Andersen", 
                     email = "andersen.dennis@outlook.com",
                     role = c("aut")),

--- a/R/source_scrapes.R
+++ b/R/source_scrapes.R
@@ -511,7 +511,7 @@ scrape_walterfootball <- function(pos = c("QB", "RB", "WR", "TE", "K"),
 
     # Combine data w/ player ID's
     pos_df <- data %>%
-      mutate(id = get_mfl_id(last = last_name, first = first_name, pos = position),
+      mutate(id = get_mfl_id(id_col = "fantasypro_id", player_name = Player, pos = position),
              data_src = "WalterFootball") %>%
       select(id, everything(), -last_name, -first_name)
 


### PR DESCRIPTION
Walterfootball is not getting the MFL IDs via the function. Switched to use the fantasypro_id so when you calculate projections they are not lost.